### PR TITLE
Fix QuestList.fromJson

### DIFF
--- a/client/src/main/scala/com/ponkotuy/parser/Post.scala
+++ b/client/src/main/scala/com/ponkotuy/parser/Post.scala
@@ -91,7 +91,9 @@ object Post extends Log {
 
   def questlist(obj: JValue)(implicit auth: Option[Auth], auth2: Option[MyFleetAuth]): Unit = {
     val qList = QuestList.fromJson(obj)
-    MFGHttp.post("/questlist", write(qList))
+    if (qList.nonEmpty) {
+      MFGHttp.post("/questlist", write(qList))
+    }
   }
 
   def swfShip(q: Query)(implicit auth: Option[Auth], auth2: Option[MyFleetAuth]): Unit = {

--- a/library/src/main/scala/com/ponkotuy/data/Quest.scala
+++ b/library/src/main/scala/com/ponkotuy/data/Quest.scala
@@ -53,7 +53,8 @@ object QuestMaterial {
 
 object QuestList {
   def fromJson(obj: JValue): List[Quest] = {
-    val JArray(xs) = obj \ "api_list"
-    xs.filter(_.isInstanceOf[JObject]).map(Quest.fromJson)
+    (obj \ "api_list").children.collect {
+      case o: JObject => Quest.fromJson(o)
+    }
   }
 }


### PR DESCRIPTION
選択したページに任務が1つしかない状態で任務を完了した場合、api_listがJNullになりMatchErrorとなっていたので修正。
合わせてリストが空の場合はサーバーにPOSTしないように変更。
