### PR TITLE
Use autoConstruct as far as possible

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.7")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 
@@ -18,6 +18,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
 
-libraryDependencies += "mysql" % "mysql-connector-java" % "[5.1,)" // Add SQLDriver
+libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.+" // Add SQLDriver
 
-addSbtPlugin("org.scalikejdbc" %% "scalikejdbc-mapper-generator" % "[2.1,)")
+addSbtPlugin("org.scalikejdbc" %% "scalikejdbc-mapper-generator" % "2.1.+")

--- a/server/app/models/db/Admiral.scala
+++ b/server/app/models/db/Admiral.scala
@@ -1,7 +1,6 @@
 package models.db
 
 import scalikejdbc._
-import scalikejdbc.{DBSession, WrappedResultSet}
 import com.ponkotuy.data
 
 /**
@@ -16,12 +15,7 @@ case class Admiral(id: Long, nicknameId: Long, nickname: String, created: Long) 
 
 object Admiral extends SQLSyntaxSupport[Admiral] {
   def apply(x: SyntaxProvider[Admiral])(rs: WrappedResultSet): Admiral = apply(x.resultName)(rs)
-  def apply(x: ResultName[Admiral])(rs: WrappedResultSet): Admiral = new Admiral(
-    rs.long(x.id),
-    rs.long(x.nicknameId),
-    rs.string(x.nickname),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[Admiral])(rs: WrappedResultSet): Admiral = autoConstruct(rs, x)
 
   lazy val a = Admiral.syntax("a")
   lazy val b = Basic.syntax("b")

--- a/server/app/models/db/Auth.scala
+++ b/server/app/models/db/Auth.scala
@@ -1,7 +1,6 @@
 package models.db
 
 import scalikejdbc._
-import scalikejdbc.{DBSession, WrappedResultSet}
 import com.ponkotuy.data
 
 /** このツール内でログイン代わりに使うパラメータ
@@ -17,11 +16,7 @@ case class Auth(id: Long, nickname: String, created: Long) {
 @deprecated("Use Admiral", "0.1-SNAPSHOT")
 object Auth extends SQLSyntaxSupport[Auth] {
   def apply(x: SyntaxProvider[Auth])(rs: WrappedResultSet): Auth = apply(x.resultName)(rs)
-  def apply(x: ResultName[Auth])(rs: WrappedResultSet): Auth = new Auth(
-    rs.long(x.id),
-    rs.string(x.nickname),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[Auth])(rs: WrappedResultSet): Auth = autoConstruct(rs, x)
 
   lazy val auth = Auth.syntax("auth")
 

--- a/server/app/models/db/Basic.scala
+++ b/server/app/models/db/Basic.scala
@@ -2,7 +2,6 @@ package models.db
 
 import scalikejdbc._
 import com.ponkotuy.data
-import scalikejdbc.{DBSession, WrappedResultSet}
 import tool.DiffCalc
 
 /**
@@ -49,15 +48,7 @@ object Basic extends SQLSyntaxSupport[Basic] {
   lazy val b = Basic.syntax("b")
 
   def apply(b: SyntaxProvider[Basic])(rs: WrappedResultSet): Basic = apply(b.resultName)(rs)
-  def apply(b: ResultName[Basic])(rs: WrappedResultSet): Basic = new Basic(
-    id = rs.long(b.id), memberId = rs.long(b.memberId),
-    lv = rs.int(b.lv), experience = rs.int(b.experience), rank = rs.int(b.rank),
-    maxChara = rs.int(b.maxChara), fCoin = rs.int(b.fCoin),
-    stWin = rs.int(b.stWin), stLose = rs.int(b.stLose),
-    msCount = rs.int(b.msCount), msSuccess = rs.int(b.msSuccess),
-    ptWin = rs.int(b.ptWin), ptLose = rs.int(b.ptLose),
-    created = rs.long(b.created)
-  )
+  def apply(b: ResultName[Basic])(rs: WrappedResultSet): Basic = autoConstruct(rs, b)
 
   def save(b: Basic)(implicit session: DBSession = Basic.autoSession): Basic = {
     withSQL {

--- a/server/app/models/db/BattleResult.scala
+++ b/server/app/models/db/BattleResult.scala
@@ -37,28 +37,12 @@ object BattleResult extends SQLSyntaxSupport[BattleResult] {
 
   override val columns = Seq("id", "member_id", "area_id", "info_no", "cell", "enemies", "win_rank", "quest_name", "quest_level", "enemy_deck", "first_clear", "get_ship_id", "get_ship_type", "get_ship_name", "created")
 
-  def apply(br: ResultName[BattleResult])(rs: WrappedResultSet): BattleResult = new BattleResult(
-    id = rs.long(br.id),
-    memberId = rs.long(br.memberId),
-    areaId = rs.int(br.areaId),
-    infoNo = rs.int(br.infoNo),
-    cell = rs.int(br.cell),
-    enemies = rs.string(br.enemies),
-    winRank = rs.string(br.winRank),
-    questName = rs.string(br.questName),
-    questLevel = rs.int(br.questLevel),
-    enemyDeck = rs.string(br.enemyDeck),
-    firstClear = rs.boolean(br.firstClear),
-    getShipId = rs.intOpt(br.getShipId),
-    getShipType = rs.stringOpt(br.getShipType),
-    getShipName = rs.stringOpt(br.getShipName),
-    created = rs.long(br.created)
-  )
+  def apply(br: ResultName[BattleResult])(rs: WrappedResultSet): BattleResult = autoConstruct(rs, br)
 
-  val br = BattleResult.syntax("br")
-  val ci = CellInfo.syntax("ci")
-  val ms = MasterShipBase.syntax("ms")
-  val a = Admiral.syntax("a")
+  lazy val br = BattleResult.syntax("br")
+  lazy val ci = CellInfo.syntax("ci")
+  lazy val ms = MasterShipBase.syntax("ms")
+  lazy val a = Admiral.syntax("a")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/CellInfo.scala
+++ b/server/app/models/db/CellInfo.scala
@@ -23,20 +23,12 @@ case class CellInfo(
 object CellInfo extends SQLSyntaxSupport[CellInfo] {
 
   override val tableName = "cell_info"
-
   override val columns = Seq("area_id", "info_no", "cell", "alphabet", "start", "boss")
 
   def apply(ci: SyntaxProvider[CellInfo])(rs: WrappedResultSet): CellInfo = apply(ci.resultName)(rs)
-  def apply(ci: ResultName[CellInfo])(rs: WrappedResultSet): CellInfo = new CellInfo(
-    areaId = rs.get(ci.areaId),
-    infoNo = rs.get(ci.infoNo),
-    cell = rs.get(ci.cell),
-    alphabet = rs.get(ci.alphabet),
-    start = rs.get(ci.start),
-    boss = rs.get(ci.boss)
-  )
+  def apply(ci: ResultName[CellInfo])(rs: WrappedResultSet): CellInfo = autoConstruct(rs, ci)
 
-  val ci = CellInfo.syntax("ci")
+  lazy val ci = CellInfo.syntax("ci")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/CreateItem.scala
+++ b/server/app/models/db/CreateItem.scala
@@ -32,20 +32,7 @@ object CreateItem extends SQLSyntaxSupport[CreateItem] {
 
   override val columns = Seq("member_id", "id", "item_id", "slotitem_id", "fuel", "ammo", "steel", "bauxite", "create_flag", "shizai_flag", "flagship", "created")
 
-  def apply(ci: ResultName[CreateItem])(rs: WrappedResultSet): CreateItem = new CreateItem(
-    memberId = rs.long(ci.memberId),
-    id = rs.long(ci.id),
-    itemId = rs.intOpt(ci.itemId),
-    slotitemId = rs.intOpt(ci.slotitemId),
-    fuel = rs.int(ci.fuel),
-    ammo = rs.int(ci.ammo),
-    steel = rs.int(ci.steel),
-    bauxite = rs.int(ci.bauxite),
-    createFlag = rs.boolean(ci.createFlag),
-    shizaiFlag = rs.boolean(ci.shizaiFlag),
-    flagship = rs.int(ci.flagship),
-    created = rs.long(ci.created)
-  )
+  def apply(ci: ResultName[CreateItem])(rs: WrappedResultSet): CreateItem = autoConstruct(rs, ci)
 
   lazy val ci = CreateItem.syntax("ci")
   lazy val mi = MasterSlotItem.syntax("mi")

--- a/server/app/models/db/CreateShip.scala
+++ b/server/app/models/db/CreateShip.scala
@@ -3,7 +3,6 @@ package models.db
 import models.join.{Mat, CShipWithAdmiral, CreateShipWithName2, CreateShipWithName}
 import scalikejdbc._
 import com.ponkotuy.data
-import scalikejdbc.{WrappedResultSet, DBSession}
 import sqls.distinct
 
 /** 建造ログ
@@ -20,20 +19,7 @@ case class CreateShip(
 
 object CreateShip extends SQLSyntaxSupport[CreateShip] {
   def apply(x: SyntaxProvider[CreateShip])(rs: WrappedResultSet): CreateShip = apply(x.resultName)(rs)
-  def apply(x: ResultName[CreateShip])(rs: WrappedResultSet): CreateShip = new CreateShip(
-    rs.long(x.memberId),
-    rs.int(x.resultShip),
-    rs.int(x.fuel),
-    rs.int(x.ammo),
-    rs.int(x.steel),
-    rs.int(x.bauxite),
-    rs.int(x.develop),
-    rs.int(x.kDock),
-    rs.boolean(x.highspeed),
-    rs.boolean(x.largeFlag),
-    rs.long(x.completeTime),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[CreateShip])(rs: WrappedResultSet): CreateShip = autoConstruct(rs, x)
 
   lazy val cs = CreateShip.syntax("cs")
   lazy val ms = MasterShipBase.syntax("ms")

--- a/server/app/models/db/DeckPort.scala
+++ b/server/app/models/db/DeckPort.scala
@@ -1,7 +1,6 @@
 package models.db
 
 import scalikejdbc._
-import scalikejdbc.{DBSession, WrappedResultSet}
 import com.ponkotuy.data
 import util.scalikejdbc.BulkInsert._
 
@@ -14,12 +13,7 @@ case class DeckPort(id: Int, memberId: Long, name: String, created: Long)
 
 object DeckPort extends SQLSyntaxSupport[DeckPort] {
   def apply(x: SyntaxProvider[DeckPort])(rs: WrappedResultSet): DeckPort = apply(x.resultName)(rs)
-  def apply(x: ResultName[DeckPort])(rs: WrappedResultSet): DeckPort = new DeckPort(
-    rs.int(x.id),
-    rs.long(x.memberId),
-    rs.string(x.name),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[DeckPort])(rs: WrappedResultSet): DeckPort = autoConstruct(rs, x)
 
   lazy val dp = DeckPort.syntax("dp")
 

--- a/server/app/models/db/DeckShip.scala
+++ b/server/app/models/db/DeckShip.scala
@@ -2,7 +2,6 @@ package models.db
 
 import models.join.{ShipWithName, DeckShipWithName}
 import scalikejdbc._
-import scalikejdbc.{DBSession, WrappedResultSet}
 import util.scalikejdbc.BulkInsert._
 
 /**
@@ -14,12 +13,7 @@ case class DeckShip(deckId: Int, num: Int, memberId: Long, shipId: Int)
 
 object DeckShip extends SQLSyntaxSupport[DeckShip] {
   def apply(x: SyntaxProvider[DeckShip])(rs: WrappedResultSet): DeckShip = apply(x.resultName)(rs)
-  def apply(x: ResultName[DeckShip])(rs: WrappedResultSet): DeckShip = new DeckShip(
-    rs.int(x.deckId),
-    rs.int(x.num),
-    rs.long(x.memberId),
-    rs.int(x.shipId)
-  )
+  def apply(x: ResultName[DeckShip])(rs: WrappedResultSet): DeckShip = autoConstruct(rs, x)
 
   lazy val ds = DeckShip.syntax("ds")
   lazy val s = Ship.syntax("s")

--- a/server/app/models/db/DeckSnapshot.scala
+++ b/server/app/models/db/DeckSnapshot.scala
@@ -25,18 +25,11 @@ object DeckSnapshot extends SQLSyntaxSupport[DeckSnapshot] {
   override val columns = Seq("id", "member_id", "name", "title", "comment", "created")
 
   def apply(ds: SyntaxProvider[DeckSnapshot])(rs: WrappedResultSet): DeckSnapshot = apply(ds.resultName)(rs)
-  def apply(ds: ResultName[DeckSnapshot])(rs: WrappedResultSet): DeckSnapshot = new DeckSnapshot(
-    id = rs.get(ds.id),
-    memberId = rs.get(ds.memberId),
-    name = rs.get(ds.name),
-    title = rs.get(ds.title),
-    comment = rs.get(ds.comment),
-    created = rs.get(ds.created)
-  )
+  def apply(ds: ResultName[DeckSnapshot])(rs: WrappedResultSet): DeckSnapshot = autoConstruct(rs, ds)
 
-  val ds = DeckSnapshot.syntax("ds")
-  val dss = DeckShipSnapshot.syntax("dss")
-  val a = Admiral.syntax("a")
+  lazy val ds = DeckSnapshot.syntax("ds")
+  lazy val dss = DeckShipSnapshot.syntax("dss")
+  lazy val a = Admiral.syntax("a")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/Favorite.scala
+++ b/server/app/models/db/Favorite.scala
@@ -28,19 +28,9 @@ object Favorite extends SQLSyntaxSupport[Favorite] {
   override val columns = Seq("id", "member_id", "url", "hash_url", "title", "first", "second", "created")
 
   def apply(f: SyntaxProvider[Favorite])(rs: WrappedResultSet): Favorite = apply(f.resultName)(rs)
+  def apply(f: ResultName[Favorite])(rs: WrappedResultSet): Favorite = autoConstruct(rs, f)
 
-  def apply(f: ResultName[Favorite])(rs: WrappedResultSet): Favorite = new Favorite(
-    id = rs.get(f.id),
-    memberId = rs.get(f.memberId),
-    url = rs.get(f.url),
-    hashUrl = rs.get(f.hashUrl),
-    title = rs.get(f.title),
-    first = rs.get(f.first),
-    second = rs.get(f.second),
-    created = rs.get(f.created)
-  )
-
-  val f = Favorite.syntax("f")
+  lazy val f = Favorite.syntax("f")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ItemBook.scala
+++ b/server/app/models/db/ItemBook.scala
@@ -23,15 +23,9 @@ object ItemBook extends SQLSyntaxSupport[ItemBook] {
 
   override val columns = Seq("member_id", "id", "index_no", "name", "updated")
 
-  def apply(ib: ResultName[ItemBook])(rs: WrappedResultSet): ItemBook = new ItemBook(
-    memberId = rs.long(ib.memberId),
-    id = rs.int(ib.id),
-    indexNo = rs.int(ib.indexNo),
-    name = rs.string(ib.name),
-    updated = rs.long(ib.updated)
-  )
+  def apply(ib: ResultName[ItemBook])(rs: WrappedResultSet): ItemBook = autoConstruct(rs, ib)
 
-  val ib = ItemBook.syntax("ib")
+  lazy val ib = ItemBook.syntax("ib")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/KDock.scala
+++ b/server/app/models/db/KDock.scala
@@ -3,7 +3,6 @@ package models.db
 import models.join.KDockWithName
 import scalikejdbc._
 import com.ponkotuy.data
-import scalikejdbc.{WrappedResultSet, DBSession}
 import util.scalikejdbc.BulkInsert._
 
 /**
@@ -17,19 +16,9 @@ case class KDock(
     fuel: Int, ammo: Int, steel: Int, bauxite: Int, created: Long)
 
 object KDock extends SQLSyntaxSupport[KDock] {
+
   def apply(x: SyntaxProvider[KDock])(rs: WrappedResultSet): KDock = apply(x.resultName)(rs)
-  def apply(x: ResultName[KDock])(rs: WrappedResultSet): KDock = new KDock(
-    rs.int(x.id),
-    rs.long(x.memberId),
-    rs.int(x.shipId),
-    rs.int(x.state),
-    rs.long(x.completeTime),
-    rs.int(x.fuel),
-    rs.int(x.ammo),
-    rs.int(x.steel),
-    rs.int(x.bauxite),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[KDock])(rs: WrappedResultSet): KDock = autoConstruct(rs, x)
 
   lazy val kd = KDock.syntax("kd")
   lazy val ms = MasterShipBase.syntax("ms")

--- a/server/app/models/db/MapInfo.scala
+++ b/server/app/models/db/MapInfo.scala
@@ -26,14 +26,9 @@ object MapInfo extends SQLSyntaxSupport[MapInfo] {
 
   override val columns = Seq("member_id", "id", "cleared", "exboss_flag")
 
-  def apply(mi: ResultName[MapInfo])(rs: WrappedResultSet): MapInfo = new MapInfo(
-    memberId = rs.long(mi.memberId),
-    id = rs.int(mi.id),
-    cleared = rs.boolean(mi.cleared),
-    exbossFlag = rs.boolean(mi.exbossFlag)
-  )
+  def apply(mi: ResultName[MapInfo])(rs: WrappedResultSet): MapInfo = autoConstruct(rs, mi)
 
-  val mi = MapInfo.syntax("mi")
+  lazy val mi = MapInfo.syntax("mi")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/MasterMission.scala
+++ b/server/app/models/db/MasterMission.scala
@@ -1,7 +1,7 @@
 package models.db
 
 import com.ponkotuy.data.master
-import scalikejdbc.{DBSession, WrappedResultSet, _}
+import scalikejdbc._
 import util.scalikejdbc.BulkInsert._
 
 /**
@@ -13,14 +13,7 @@ case class MasterMission(id: Int, mapArea: Int, name: String, time: Int, fuel: D
 
 object MasterMission extends SQLSyntaxSupport[MasterMission] {
   def apply(x: SyntaxProvider[MasterMission])(rs: WrappedResultSet): MasterMission = apply(x.resultName)(rs)
-  def apply(x: ResultName[MasterMission])(rs: WrappedResultSet): MasterMission = new MasterMission(
-    rs.int(x.id),
-    rs.int(x.mapArea),
-    rs.string(x.name),
-    rs.int(x.time),
-    rs.double(x.fuel),
-    rs.double(x.ammo)
-  )
+  def apply(x: ResultName[MasterMission])(rs: WrappedResultSet): MasterMission = autoConstruct(rs, x)
 
   lazy val mm = MasterMission.syntax("mm")
 

--- a/server/app/models/db/MasterShipAfter.scala
+++ b/server/app/models/db/MasterShipAfter.scala
@@ -25,15 +25,9 @@ object MasterShipAfter extends SQLSyntaxSupport[MasterShipAfter] {
   override val columns = Seq("id", "afterlv", "aftershipid", "afterfuel", "afterbull")
 
   def apply(msa: SyntaxProvider[MasterShipAfter])(rs: WrappedResultSet): MasterShipAfter = apply(msa.resultName)(rs)
-  def apply(msa: ResultName[MasterShipAfter])(rs: WrappedResultSet): MasterShipAfter = new MasterShipAfter(
-    id = rs.int(msa.id),
-    afterlv = rs.int(msa.afterlv),
-    aftershipid = rs.int(msa.aftershipid),
-    afterfuel = rs.int(msa.afterfuel),
-    afterbull = rs.int(msa.afterbull)
-  )
+  def apply(msa: ResultName[MasterShipAfter])(rs: WrappedResultSet): MasterShipAfter = autoConstruct(rs, msa)
 
-  val msa = MasterShipAfter.syntax("msa")
+  lazy val msa = MasterShipAfter.syntax("msa")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/MasterShipBase.scala
+++ b/server/app/models/db/MasterShipBase.scala
@@ -2,7 +2,7 @@ package models.db
 
 import com.ponkotuy.data.master
 import models.join.{MasterShipWithStype, MasterShipAll}
-import scalikejdbc.{DBSession, WrappedResultSet, _}
+import scalikejdbc._
 
 /**
  *
@@ -16,14 +16,7 @@ case class MasterShipBase(
 object MasterShipBase extends SQLSyntaxSupport[MasterShipBase] {
   override val tableName = "master_ship"
   def apply(x: SyntaxProvider[MasterShipBase])(rs: WrappedResultSet): MasterShipBase = apply(x.resultName)(rs)
-  def apply(x: ResultName[MasterShipBase])(rs: WrappedResultSet): MasterShipBase = new MasterShipBase(
-    rs.int(x.id),
-    rs.string(x.name),
-    rs.string(x.yomi),
-    rs.int(x.sortno),
-    rs.int(x.stype),
-    rs.string(x.filename)
-  )
+  def apply(x: ResultName[MasterShipBase])(rs: WrappedResultSet): MasterShipBase = autoConstruct(rs, x)
 
   lazy val ms = MasterShipBase.syntax("ms")
   lazy val mss = MasterShipSpecs.syntax("mss")

--- a/server/app/models/db/MasterShipOther.scala
+++ b/server/app/models/db/MasterShipOther.scala
@@ -34,24 +34,9 @@ object MasterShipOther extends SQLSyntaxSupport[MasterShipOther] {
   override val columns = Seq("id", "buildtime", "broken_fuel", "broken_ammo", "broken_steel", "broken_bauxite", "powup_fuel", "powup_ammo", "powup_steel", "powup_bauxite", "backs", "fuel_max", "bull_max", "slot_num")
 
   def apply(mso: SyntaxProvider[MasterShipOther])(rs: WrappedResultSet): MasterShipOther = apply(mso.resultName)(rs)
-  def apply(mso: ResultName[MasterShipOther])(rs: WrappedResultSet): MasterShipOther = new MasterShipOther(
-    id = rs.int(mso.id),
-    buildtime = rs.int(mso.buildtime),
-    brokenFuel = rs.int(mso.brokenFuel),
-    brokenAmmo = rs.int(mso.brokenAmmo),
-    brokenSteel = rs.int(mso.brokenSteel),
-    brokenBauxite = rs.int(mso.brokenBauxite),
-    powupFuel = rs.int(mso.powupFuel),
-    powupAmmo = rs.int(mso.powupAmmo),
-    powupSteel = rs.int(mso.powupSteel),
-    powupBauxite = rs.int(mso.powupBauxite),
-    backs = rs.int(mso.backs),
-    fuelMax = rs.int(mso.fuelMax),
-    bullMax = rs.int(mso.bullMax),
-    slotNum = rs.int(mso.slotNum)
-  )
+  def apply(mso: ResultName[MasterShipOther])(rs: WrappedResultSet): MasterShipOther = autoConstruct(rs, mso)
 
-  val mso = MasterShipOther.syntax("mso")
+  lazy val mso = MasterShipOther.syntax("mso")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/MasterStype.scala
+++ b/server/app/models/db/MasterStype.scala
@@ -23,16 +23,11 @@ object MasterStype extends SQLSyntaxSupport[MasterStype] {
   override val tableName = "master_stype"
 
   override val columns = Seq("id", "sortno", "name", "scnt", "kcnt")
-  def apply(x: SyntaxProvider[MasterStype])(rs: WrappedResultSet): MasterStype = apply(x.resultName)(rs)
-  def apply(ms: ResultName[MasterStype])(rs: WrappedResultSet): MasterStype = new MasterStype(
-    id = rs.int(ms.id),
-    sortno = rs.int(ms.sortno),
-    name = rs.string(ms.name),
-    scnt = rs.int(ms.scnt),
-    kcnt = rs.int(ms.kcnt)
-  )
 
-  val ms = MasterStype.syntax("ms")
+  def apply(x: SyntaxProvider[MasterStype])(rs: WrappedResultSet): MasterStype = apply(x.resultName)(rs)
+  def apply(ms: ResultName[MasterStype])(rs: WrappedResultSet): MasterStype = autoConstruct(rs, ms)
+
+  lazy val ms = MasterStype.syntax("ms")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/Material.scala
+++ b/server/app/models/db/Material.scala
@@ -2,7 +2,6 @@ package models.db
 
 import scalikejdbc._
 import com.ponkotuy.data
-import scalikejdbc.{DBSession, WrappedResultSet}
 import tool.DiffCalc
 
 /**
@@ -42,19 +41,7 @@ object Material extends SQLSyntaxSupport[Material] {
   lazy val m = Material.syntax("m")
 
   def apply(m: SyntaxProvider[Material])(rs: WrappedResultSet): Material = apply(m.resultName)(rs)
-  def apply(m: ResultName[Material])(rs: WrappedResultSet): Material = new Material(
-    id = rs.long(m.id),
-    memberId = rs.long(m.memberId),
-    fuel = rs.int(m.fuel),
-    ammo = rs.int(m.ammo),
-    steel = rs.int(m.steel),
-    bauxite = rs.int(m.bauxite),
-    instant = rs.int(m.instant),
-    bucket = rs.int(m.bucket),
-    develop = rs.int(m.develop),
-    revamping = rs.int(m.revamping),
-    created = rs.long(m.created)
-  )
+  def apply(m: ResultName[Material])(rs: WrappedResultSet): Material = autoConstruct(rs, m)
 
   def save(m: Material)(implicit session: DBSession = Material.autoSession): Material = {
     withSQL {

--- a/server/app/models/db/Mission.scala
+++ b/server/app/models/db/Mission.scala
@@ -2,7 +2,6 @@ package models.db
 
 import models.join.MissionWithFlagship
 import scalikejdbc._
-import scalikejdbc.{DBSession, WrappedResultSet}
 import com.ponkotuy.data
 import util.scalikejdbc.BulkInsert._
 
@@ -14,15 +13,9 @@ import util.scalikejdbc.BulkInsert._
 case class Mission(memberId: Long, deckId: Int, page: Int, number: Int, completeTime: Long, created: Long)
 
 object Mission extends SQLSyntaxSupport[Mission] {
+
   def apply(x: SyntaxProvider[Mission])(rs: WrappedResultSet): Mission = apply(x.resultName)(rs)
-  def apply(x: ResultName[Mission])(rs: WrappedResultSet): Mission = new Mission(
-    rs.long(x.memberId),
-    rs.int(x.deckId),
-    rs.int(x.page),
-    rs.int(x.number),
-    rs.long(x.completeTime),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[Mission])(rs: WrappedResultSet): Mission = autoConstruct(rs, x)
 
   lazy val m = Mission.syntax("m")
   lazy val mm = MasterMission.syntax("mm")

--- a/server/app/models/db/MyFleetAuth.scala
+++ b/server/app/models/db/MyFleetAuth.scala
@@ -22,14 +22,9 @@ object MyFleetAuth extends SQLSyntaxSupport[MyFleetAuth] {
   override val columns = Seq("id", "hash", "salt", "created")
 
   def apply(mfa: SyntaxProvider[MyFleetAuth])(rs: WrappedResultSet): MyFleetAuth = apply(mfa.resultName)(rs)
-  def apply(mfa: ResultName[MyFleetAuth])(rs: WrappedResultSet): MyFleetAuth = new MyFleetAuth(
-    id = rs.get(mfa.id),
-    hash = rs.get(mfa.hash),
-    salt = rs.get(mfa.salt),
-    created = rs.get(mfa.created)
-  )
+  def apply(mfa: ResultName[MyFleetAuth])(rs: WrappedResultSet): MyFleetAuth = autoConstruct(rs, mfa)
 
-  val mfa = MyFleetAuth.syntax("mfa")
+  lazy val mfa = MyFleetAuth.syntax("mfa")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/NDock.scala
+++ b/server/app/models/db/NDock.scala
@@ -12,14 +12,9 @@ import com.ponkotuy.data
 case class NDock(id: Int, memberId: Long, shipId: Int, completeTime: Long, created: Long)
 
 object NDock extends SQLSyntaxSupport[NDock] {
+
   def apply(x: SyntaxProvider[NDock])(rs: WrappedResultSet): NDock = apply(x.resultName)(rs)
-  def apply(x: ResultName[NDock])(rs: WrappedResultSet): NDock = new NDock(
-    rs.int(x.id),
-    rs.long(x.memberId),
-    rs.int(x.shipId),
-    rs.long(x.completeTime),
-    rs.long(x.created)
-  )
+  def apply(x: ResultName[NDock])(rs: WrappedResultSet): NDock = autoConstruct(rs, x)
 
   lazy val nd = NDock.syntax("nd")
   lazy val s = Ship.syntax("s")

--- a/server/app/models/db/Quest.scala
+++ b/server/app/models/db/Quest.scala
@@ -34,24 +34,9 @@ object Quest extends SQLSyntaxSupport[Quest] {
   override val columns = Seq("member_id", "id", "category", "typ", "state", "title", "detail", "fuel", "ammo", "steel", "bauxite", "bonus", "progress_flag", "created")
 
   def apply(q: SyntaxProvider[Quest])(rs: WrappedResultSet): Quest = apply(q.resultName)(rs)
-  def apply(q: ResultName[Quest])(rs: WrappedResultSet): Quest = new Quest(
-    memberId = rs.get(q.memberId),
-    id = rs.get(q.id),
-    category = rs.get(q.category),
-    typ = rs.get(q.typ),
-    state = rs.get(q.state),
-    title = rs.get(q.title),
-    detail = rs.get(q.detail),
-    fuel = rs.get(q.fuel),
-    ammo = rs.get(q.ammo),
-    steel = rs.get(q.steel),
-    bauxite = rs.get(q.bauxite),
-    bonus = rs.get(q.bonus),
-    progressFlag = rs.get(q.progressFlag),
-    created = rs.get(q.created)
-  )
+  def apply(q: ResultName[Quest])(rs: WrappedResultSet): Quest = autoConstruct(rs, q)
 
-  val q = Quest.syntax("q")
+  lazy val q = Quest.syntax("q")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/RemodelSlot.scala
+++ b/server/app/models/db/RemodelSlot.scala
@@ -36,24 +36,10 @@ object RemodelSlot extends SQLSyntaxSupport[RemodelSlot] {
   override val columns = Seq("id", "slot_id", "member_id", "second_ship", "fuel", "ammo", "steel", "bauxite", "develop", "revamping", "req_slot_id", "slot_num", "created")
 
   def apply(r: SyntaxProvider[RemodelSlot])(rs: WrappedResultSet): RemodelSlot = apply(r.resultName)(rs)
-  def apply(r: ResultName[RemodelSlot])(rs: WrappedResultSet): RemodelSlot = new RemodelSlot(
-    id = rs.get(r.id),
-    slotId = rs.get(r.slotId),
-    memberId = rs.get(r.memberId),
-    secondShip = rs.get(r.secondShip),
-    fuel = rs.get(r.fuel),
-    ammo = rs.get(r.ammo),
-    steel = rs.get(r.steel),
-    bauxite = rs.get(r.bauxite),
-    develop = rs.get(r.develop),
-    revamping = rs.get(r.revamping),
-    reqSlotId = rs.get(r.reqSlotId),
-    slotNum = rs.get(r.slotNum),
-    created = rs.get(r.created)
-  )
+  def apply(r: ResultName[RemodelSlot])(rs: WrappedResultSet): RemodelSlot = autoConstruct(rs, r)
 
-  val r = RemodelSlot.syntax("r")
-  val ms = MasterShipBase.syntax("ms")
+  lazy val r = RemodelSlot.syntax("r")
+  lazy val ms = MasterShipBase.syntax("ms")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/Session.scala
+++ b/server/app/models/db/Session.scala
@@ -26,14 +26,9 @@ object Session extends SQLSyntaxSupport[Session] {
   override val columns = Seq("uuid_most", "uuid_least", "member_id", "created")
 
   def apply(s: SyntaxProvider[Session])(rs: WrappedResultSet): Session = apply(s.resultName)(rs)
-  def apply(s: ResultName[Session])(rs: WrappedResultSet): Session = new Session(
-    uuidMost = rs.get(s.uuidMost),
-    uuidLeast = rs.get(s.uuidLeast),
-    memberId = rs.get(s.memberId),
-    created = rs.get(s.created)
-  )
+  def apply(s: ResultName[Session])(rs: WrappedResultSet): Session = autoConstruct(rs, s)
 
-  val s = Session.syntax("s")
+  lazy val s = Session.syntax("s")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ShipBattleResult.scala
+++ b/server/app/models/db/ShipBattleResult.scala
@@ -22,15 +22,9 @@ object ShipBattleResult extends SQLSyntaxSupport[ShipBattleResult] {
 
   override val columns = Seq("battle_id", "member_id", "id", "exp", "lost_flag")
 
-  def apply(sbr: ResultName[ShipBattleResult])(rs: WrappedResultSet): ShipBattleResult = new ShipBattleResult(
-    battleId = rs.long(sbr.battleId),
-    memberId = rs.long(sbr.memberId),
-    id = rs.byte(sbr.id),
-    exp = rs.int(sbr.exp),
-    lostFlag = rs.boolean(sbr.lostFlag)
-  )
+  def apply(sbr: ResultName[ShipBattleResult])(rs: WrappedResultSet): ShipBattleResult = autoConstruct(rs, sbr)
 
-  val sbr = ShipBattleResult.syntax("sbr")
+  lazy val sbr = ShipBattleResult.syntax("sbr")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ShipBook.scala
+++ b/server/app/models/db/ShipBook.scala
@@ -25,18 +25,10 @@ object ShipBook extends SQLSyntaxSupport[ShipBook] {
 
   override val columns = Seq("member_id", "id", "index_no", "is_dameged", "name", "updated", "is_married")
 
-  def apply(sb: ResultName[ShipBook])(rs: WrappedResultSet): ShipBook = new ShipBook(
-    memberId = rs.long(sb.memberId),
-    id = rs.int(sb.id),
-    indexNo = rs.int(sb.indexNo),
-    isDameged = rs.boolean(sb.isDameged),
-    name = rs.string(sb.name),
-    updated = rs.long(sb.updated),
-    isMarried = rs.boolean(sb.isMarried)
-  )
+  def apply(sb: ResultName[ShipBook])(rs: WrappedResultSet): ShipBook = autoConstruct(rs, sb)
 
-  val sb = ShipBook.syntax("sb")
-  val ms = MasterShipBase.syntax("ms")
+  lazy val sb = ShipBook.syntax("sb")
+  lazy val ms = MasterShipBase.syntax("ms")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ShipImage.scala
+++ b/server/app/models/db/ShipImage.scala
@@ -21,16 +21,10 @@ object ShipImage extends SQLSyntaxSupport[ShipImage] {
 
   override val columns = Seq("id", "image", "filename", "member_id", "swf_id")
 
-  def apply(si: ResultName[ShipImage])(rs: WrappedResultSet): ShipImage = new ShipImage(
-    id = rs.int(si.id),
-    image = rs.bytes(si.image),
-    filename = rs.string(si.filename),
-    memberId = rs.long(si.memberId),
-    swfId = rs.int(si.swfId)
-  )
+  def apply(si: ResultName[ShipImage])(rs: WrappedResultSet): ShipImage = autoConstruct(rs, si)
 
-  val si = ShipImage.syntax("si")
-  val a = Admiral.syntax("a")
+  lazy val si = ShipImage.syntax("si")
+  lazy val a = Admiral.syntax("a")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ShipSlotItem.scala
+++ b/server/app/models/db/ShipSlotItem.scala
@@ -22,14 +22,9 @@ object ShipSlotItem extends SQLSyntaxSupport[ShipSlotItem] {
 
   override val columns = Seq("member_id", "ship_id", "id", "slotitem_id")
 
-  def apply(ssi: ResultName[ShipSlotItem])(rs: WrappedResultSet): ShipSlotItem = new ShipSlotItem(
-    memberId = rs.long(ssi.memberId),
-    shipId = rs.int(ssi.shipId),
-    id = rs.int(ssi.id),
-    slotitemId = rs.int(ssi.slotitemId)
-  )
+  def apply(ssi: ResultName[ShipSlotItem])(rs: WrappedResultSet): ShipSlotItem = autoConstruct(rs, ssi)
 
-  val ssi = ShipSlotItem.syntax("ssi")
+  lazy val ssi = ShipSlotItem.syntax("ssi")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/ShipSound.scala
+++ b/server/app/models/db/ShipSound.scala
@@ -1,7 +1,6 @@
 package models.db
 
 import scalikejdbc._
-import scalikejdbc.{AutoSession, WrappedResultSet, DBSession}
 
 import scala.util.Random
 
@@ -23,14 +22,10 @@ object ShipSound extends SQLSyntaxSupport[ShipSound] {
 
   override val columns = Seq("ship_id", "sound_id", "sound")
 
-  def apply(ss: ResultName[ShipSound])(rs: WrappedResultSet): ShipSound = new ShipSound(
-    shipId = rs.int(ss.shipId),
-    soundId = rs.int(ss.soundId),
-    sound = rs.bytes(ss.sound)
-  )
+  def apply(ss: ResultName[ShipSound])(rs: WrappedResultSet): ShipSound = autoConstruct(rs, ss)
 
-  val ss = ShipSound.syntax("ss")
-  val ms = MasterShipBase.syntax("ms")
+  lazy val ss = ShipSound.syntax("ss")
+  lazy val ms = MasterShipBase.syntax("ms")
 
   override val autoSession = AutoSession
 

--- a/server/app/models/db/SlotItem.scala
+++ b/server/app/models/db/SlotItem.scala
@@ -31,14 +31,7 @@ object SlotItem extends SQLSyntaxSupport[SlotItem] {
   override val columns = Seq("member_id", "id", "slotitem_id", "name", "locked", "level")
 
   def apply(si: SyntaxProvider[SlotItem])(rs: WrappedResultSet): SlotItem = SlotItem(si.resultName)(rs)
-  def apply(si: ResultName[SlotItem])(rs: WrappedResultSet): SlotItem = new SlotItem(
-    memberId = rs.long(si.memberId),
-    id = rs.int(si.id),
-    slotitemId = rs.int(si.slotitemId),
-    name = rs.string(si.name),
-    locked = rs.boolean(si.locked),
-    level = rs.int(si.level)
-  )
+  def apply(si: ResultName[SlotItem])(rs: WrappedResultSet): SlotItem = autoConstruct(rs, si)
 
   lazy val si = SlotItem.syntax("si")
   lazy val ssi = ShipSlotItem.syntax("ssi")

--- a/server/app/models/db/UserSettings.scala
+++ b/server/app/models/db/UserSettings.scala
@@ -25,11 +25,7 @@ object UserSettings extends SQLSyntaxSupport[UserSettings] {
   override val columns = Seq("member_id", "yome", "base")
 
   def apply(us: SyntaxProvider[UserSettings])(rs: WrappedResultSet): UserSettings = apply(us.resultName)(rs)
-  def apply(us: ResultName[UserSettings])(rs: WrappedResultSet): UserSettings = new UserSettings(
-    memberId = rs.get(us.memberId),
-    yome = rs.get(us.yome),
-    base = rs.get(us.base)
-  )
+  def apply(us: ResultName[UserSettings])(rs: WrappedResultSet): UserSettings = autoConstruct(rs, us)
 
   lazy val us = UserSettings.syntax("us")
   lazy val s = Ship.syntax("s")

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -8,12 +8,12 @@ val scalikeJdbcVer = "2.2.+"
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % scalikeJdbcVer,
   "org.scalikejdbc" %% "scalikejdbc-config" % scalikeJdbcVer,
-  "org.scalikejdbc" %% "scalikejdbc-interpolation" % scalikeJdbcVer,
+  "org.scalikejdbc" %% "scalikejdbc-syntax-support-macro" % scalikeJdbcVer,
   "org.json4s" %% "json4s-native" % "3.2.11",
   "com.github.tototoshi" %% "play-flyway" % "1.1.2",
   "com.github.nscala-time" %% "nscala-time" % "1.6.0",
-  "mysql" % "mysql-connector-java" % "[5.1,)",
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "mysql" % "mysql-connector-java" % "5.1.+",
+  "org.scalatest" %% "scalatest" % "2.2.3" % "test",
   "c3p0" % "c3p0" % "0.9.1.2",
   "org.apache.abdera" % "abdera-parser" % "1.1.3",
   "net.sf.ehcache" % "ehcache" % "2.9.0"


### PR DESCRIPTION
server/compile までは確認していますが、動作させての確認はしていないので念のため動作確認してください。

- scalikejdbc-syntax-support-macro を dependencies に追加すると単純な WrappedResultSet からの取り出しを省略できます
- skinny-orm を使ったほうが良さそうなコードが多いですが、ボリュームがあって大変そうなので作業を見送りました
- "[2.1,)" のような指定は 2.2.x までとりにいくので "2.1.+" としたほうがよいです
- play 2.3.7 など細かいバージョンをあげています
