### PR TITLE
「ドック/Condition回復」に所属艦隊番号を表示する

### DIFF
--- a/server/app/assets/javascript/dock.coffee
+++ b/server/app/assets/javascript/dock.coffee
@@ -50,7 +50,7 @@ $(document).ready ->
 
       checkdata: (that) ->
         () ->
-          $.getJSON "/rest/v1/#{userId}/ndocks", (data) ->
+          $.getJSON "/rest/v2/#{userId}/ndocksWithDeckId", (data) ->
             that.onNdock(data)
           $.getJSON "/rest/v1/#{userId}/kdocks", (data) ->
             that.onKdock(data)

--- a/server/app/controllers/RestUser.scala
+++ b/server/app/controllers/RestUser.scala
@@ -19,6 +19,8 @@ object RestUser extends Controller {
 
   def ndocks(memberId: Long) = returnJson(db.NDock.findAllByUserWithName(memberId))
 
+  def ndocksWithDeckId(memberId: Long) = returnJson(db.NDock.findAllByUserWithDeckId(memberId))
+
   def kdocks(memberId: Long) = returnJson(db.KDock.findAllByUserWithName(memberId))
 
   def missions(memberId: Long) = returnJson(db.Mission.findByUserWithFlagship(memberId))

--- a/server/app/models/join/NDockWithDeckId.scala
+++ b/server/app/models/join/NDockWithDeckId.scala
@@ -1,0 +1,9 @@
+package models.join
+
+case class NDockWithDeckId(
+  id: Int,
+  memberId: Long,
+  shipId: Int,
+  completeTime: Long,
+  created: Long,
+  deckId: Option[Int])

--- a/server/app/views/user/dock.scala.html
+++ b/server/app/views/user/dock.scala.html
@@ -36,7 +36,7 @@
               <tbody>
                 <tr v-repeat="dock: ndocks">
                   <td>{{dock.id}}</td>
-                  <td><a href="@routes.UserView.ship(user.admiral.id)#modal=true&id={{dock.shipId}}">{{dock.name}}</a></td>
+                  <td><a href="@routes.UserView.ship(user.admiral.id)#modal=true&id={{dock.shipId}}">{{dock.name}}</a><small v-if="dock.deckId">{{dock.deckId}}</small></td>
                   <td>{{timeView(dock.completeTime, '修復完了')}}</td>
                 </tr>
               </tbody>

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -66,6 +66,7 @@ GET     /rest/v2/master/stype/hash  controllers.Rest.stypeHash
 GET     /rest/v1/:userId/materials  controllers.RestUser.materials(userId: Long)
 GET     /rest/v1/:userId/basics     controllers.RestUser.basics(userId: Long)
 GET     /rest/v1/:userId/ndocks     controllers.RestUser.ndocks(userId: Long)
+GET     /rest/v2/:userId/ndocksWithDeckId controllers.RestUser.ndocksWithDeckId(userId: Long)
 GET     /rest/v1/:userId/kdocks     controllers.RestUser.kdocks(userId: Long)
 GET     /rest/v1/:userId/missions   controllers.RestUser.missions(userId: Long)
 GET     /rest/v1/:userId/conds      controllers.RestUser.conds(userId: Long)


### PR DESCRIPTION
#132
コンパイルが通ることしか確認してません。
艦隊名を表示すると、艦隊名が長い場合に見た目としてめんどくさいことになりそうなので番号にしてあります。