### PR TITLE
Docker: MariaDB charset options

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -9,4 +9,4 @@ play:
     - ~/.sbt:/root/.sbt
 db:
   image: dockerfile/mariadb
-  command: bash -c 'echo "mysqld_safe &" > /tmp/config && echo "mysqladmin --silent --wait=30 ping || exit 1" >> /tmp/config && echo "mysql -e \"CREATE DATABASE IF NOT EXISTS myfleet;\"" >> /tmp/config && bash /tmp/config && rm -f /tmp/config && killall mysqld && sleep 5 && mysqld_safe'
+  command: bash -c 'echo "mysqld_safe &" > /tmp/config && echo "mysqladmin --silent --wait=30 ping || exit 1" >> /tmp/config && echo "mysql -e \"CREATE DATABASE IF NOT EXISTS myfleet;\"" >> /tmp/config && bash /tmp/config && rm -f /tmp/config && killall mysqld && sleep 5 && mysqld_safe --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci'


### PR DESCRIPTION
docker/figで起動した環境で日本語が扱えない問題の修正。
mysqld_safeの引数で指定する形にした。