### PR TITLE
Fix exception with empty ranking

### DIFF
--- a/server/app/honor/RankingTop.scala
+++ b/server/app/honor/RankingTop.scala
@@ -18,8 +18,7 @@ object RankingTop extends HonorCategory {
       RankingType.Admiral.rankings.map(it => it -> it.rankingQuery(20))(breakOut)
     val admiralName = Admiral.find(memberId).map(_.nickname)
     val tops = rankings.filter { case (admiral, xs) =>
-      val top = xs.head.num
-      xs.takeWhile(_.num == top).exists(x => admiralName.contains(x.name))
+      xs.headOption.exists(top => xs.takeWhile(_.num == top.num).exists(x => admiralName.contains(x.name)))
     }.keys
     val ins = rankings.filter { case (_, xs) => xs.exists(x => admiralName.contains(x.name)) }.keys
     (tops.map(top => s"${top.title}トップ") ++ ins.map(in => s"${in.title}ランクイン")).toList


### PR DESCRIPTION
空の提督ランキングがある状態でユーザーの称号画面に入ると例外が発生する。
誰も図鑑を登録してない場合等。

`head`ダメゼッタイ(論理的に例外が起きない場合を除く)