### PR TITLE
POST メソッドの時もリダイレクトを有効にするように設定

### DIFF
--- a/client/src/main/scala/com/ponkotuy/http/MFGHttp.scala
+++ b/client/src/main/scala/com/ponkotuy/http/MFGHttp.scala
@@ -15,6 +15,7 @@ import org.apache.http.entity.ContentType
 import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.client.LaxRedirectStrategy
 import org.apache.http.message.BasicNameValuePair
 import org.json4s._
 import org.json4s.native.Serialization
@@ -38,6 +39,7 @@ object MFGHttp extends Log {
   val httpBuilder = HttpClientBuilder.create()
       .setDefaultRequestConfig(config)
       .setSslcontext(sslContext)
+      .setRedirectStrategy(new LaxRedirectStrategy())
 
   implicit val formats = Serialization.formats(NoTypeHints)
 


### PR DESCRIPTION
HttpClient はデフォルトでは POST リクエストに対する 301,302 等のレスポンスコードには従わない。
おそらく「 RFC 的には POST のままリダイレクトすべき・しかし既存の実装の多くは GET でリダイレクトしてしまう」という状況をみて、コーディング側で対処しろと言う事と思われる。

で、いくつかの情報をあたったところ Redirect に対するポリシー的な部分（RedirectStrategy）を置き換えてやれば良いとのこと。
素直には出てこないが LaxRedirectStrategy が同梱されており、ソースを見る限り以下の挙動となっており、目的に一番マッチしている。

* 対象は GET / POST / HEAD リクエスト
* 対応するレスポンスコードは 301, 302, 303, 307

参考情報
http://www.baeldung.com/httpclient-redirect-on-http-post
https://apache.googlesource.com/httpclient/+/trunk-adaptive-connpool/httpclient/src/main/java/org/apache/http/impl/client/LaxRedirectStrategy.java