### PR TITLE
ファイルダウンロード時に一時ファイルを使用するように変更

### DIFF
--- a/update/src/main/java/Connection.java
+++ b/update/src/main/java/Connection.java
@@ -51,7 +51,7 @@ public class Connection {
         tempFile.toFile().deleteOnExit();
         try(InputStream is = conn.getInputStream()) {
             if(content == null) {
-                Files.copy(is, tempFile);
+                Files.copy(is, tempFile, REPLACE_EXISTING);
                 Files.copy(tempFile, dst, REPLACE_EXISTING);
             } else switch (content) {
                 case "pack200-gzip":
@@ -60,12 +60,12 @@ public class Connection {
                     break;
                 case "gzip":
                     try(GZIPInputStream gzipIs = new GZIPInputStream(is)){
-                        Files.copy(gzipIs, tempFile);
+                        Files.copy(gzipIs, tempFile, REPLACE_EXISTING);
                     }
                     Files.copy(tempFile, dst, REPLACE_EXISTING);
                     break;
                 default:
-                    Files.copy(is, tempFile);
+                    Files.copy(is, tempFile, REPLACE_EXISTING);
                     Files.copy(tempFile, dst, REPLACE_EXISTING);
             }
         }

--- a/update/src/main/java/Connection.java
+++ b/update/src/main/java/Connection.java
@@ -47,20 +47,26 @@ public class Connection {
 
     public static void download(URLConnection conn, Path dst) throws IOException {
         String content = conn.getHeaderField("Content-Encoding");
+        Path tempFile = Files.createTempFile("myfleetgirls",null);
+        tempFile.toFile().deleteOnExit();
         try(InputStream is = conn.getInputStream()) {
             if(content == null) {
-                Files.copy(is, dst, REPLACE_EXISTING);
+                Files.copy(is, tempFile);
+                Files.copy(tempFile, dst, REPLACE_EXISTING);
             } else switch (content) {
                 case "pack200-gzip":
-                    pack20ODownload(conn, dst);
+                    pack20ODownload(conn, tempFile);
+                    Files.copy(tempFile, dst, REPLACE_EXISTING);
                     break;
                 case "gzip":
                     try(GZIPInputStream gzipIs = new GZIPInputStream(is)){
-                        Files.copy(gzipIs, dst, REPLACE_EXISTING);
+                        Files.copy(gzipIs, tempFile);
                     }
+                    Files.copy(tempFile, dst, REPLACE_EXISTING);
                     break;
                 default:
-                    Files.copy(is, dst, REPLACE_EXISTING);
+                    Files.copy(is, tempFile);
+                    Files.copy(tempFile, dst, REPLACE_EXISTING);
             }
         }
 

--- a/update/src/main/java/Connection.java
+++ b/update/src/main/java/Connection.java
@@ -55,7 +55,9 @@ public class Connection {
                     pack20ODownload(conn, dst);
                     break;
                 case "gzip":
-                    Files.copy(new GZIPInputStream(is), dst, REPLACE_EXISTING);
+                    try(GZIPInputStream gzipIs = new GZIPInputStream(is)){
+                        Files.copy(gzipIs, dst, REPLACE_EXISTING);
+                    }
                     break;
                 default:
                     Files.copy(is, dst, REPLACE_EXISTING);
@@ -70,10 +72,11 @@ public class Connection {
 
     public static void pack20ODownload(URLConnection conn, Path dst) throws IOException {
         try(InputStream is = conn.getInputStream();
+            GZIPInputStream gzipIs = new GZIPInputStream(is);
             OutputStream os = Files.newOutputStream(dst, WRITE, CREATE, TRUNCATE_EXISTING);
             JarOutputStream jar = new JarOutputStream(os)) {
             Pack200.Unpacker unpacker = Pack200.newUnpacker();
-            unpacker.unpack(new GZIPInputStream(is), jar);
+            unpacker.unpack(gzipIs, jar);
         }
     }
 }

--- a/update/src/main/java/Connection.java
+++ b/update/src/main/java/Connection.java
@@ -68,6 +68,8 @@ public class Connection {
                     Files.copy(is, tempFile, REPLACE_EXISTING);
                     Files.copy(tempFile, dst, REPLACE_EXISTING);
             }
+        }finally{
+            Files.deleteIfExists(tempFile);
         }
 
         long requestModified = conn.getLastModified();


### PR DESCRIPTION
ダウンロード中のエラーには対処出来るはず。
これで #175 の症状が軽減されれば良いが。（おそらく根本的な対処では無い）