### PR TITLE
[WIP] ログ出力機能の追加＆設定

### DIFF
--- a/client/build.sbt
+++ b/client/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= Seq(
   "com.netaporter" %% "scala-uri" % "0.4.4",
   "org.json4s" %% "json4s-native" % "3.2.11",
   "org.apache.httpcomponents" % "httpclient" % "4.4",
-  "org.apache.httpcomponents" % "httpmime" % "4.4"
+  "org.apache.httpcomponents" % "httpmime" % "4.4",
+  "org.apache.logging.log4j" %% "log4j-core" % "1.2.14"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.2.11",
   "org.apache.httpcomponents" % "httpclient" % "4.4",
   "org.apache.httpcomponents" % "httpmime" % "4.4",
-  "org.apache.logging.log4j" %% "log4j-core" % "1.2.14"
+  "org.apache.logging.log4j" %% "log4j-core" % "2.2"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -13,7 +13,11 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.2.11",
   "org.apache.httpcomponents" % "httpclient" % "4.4",
   "org.apache.httpcomponents" % "httpmime" % "4.4",
-  "org.apache.logging.log4j" % "log4j-core" % "2.2"
+  "org.slf4j" % "slf4j-api" % "1.7.10",
+  "org.slf4j" % "jul-to-slf4j" % "1.7.10",
+  "org.apache.logging.log4j" % "log4j-core" % "2.2",
+  "org.apache.logging.log4j" % "log4j-1.2-api" % "2.2",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.2"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.2.11",
   "org.apache.httpcomponents" % "httpclient" % "4.4",
   "org.apache.httpcomponents" % "httpmime" % "4.4",
-  "org.apache.logging.log4j" %% "log4j-core" % "2.2"
+  "org.apache.logging.log4j" % "log4j-core" % "2.2"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")

--- a/client/src/main/resources/log4j.properties
+++ b/client/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%c] %m%n
+
+log4j.logger.org.apache.http=DEBUG
+log4j.logger.org.apache.http.wire=ERROR

--- a/client/src/main/resources/log4j.properties
+++ b/client/src/main/resources/log4j.properties
@@ -4,5 +4,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%c] %m%n
 
-log4j.logger.org.apache.http=DEBUG
-log4j.logger.org.apache.http.wire=ERROR
+#log4j.logger.org.apache.http=DEBUG
+#log4j.logger.org.apache.http.wire=ERROR

--- a/package/debug/log4j.properties
+++ b/package/debug/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%c] %m%n
+
+log4j.logger.com.ponkotuy=DEBUG
+
+log4j.logger.org.apache.http=DEBUG
+log4j.logger.org.apache.http.wire=ERROR

--- a/package/debug/myfleetgirls-debug.sh
+++ b/package/debug/myfleetgirls-debug.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd `dirname $0`
+java -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog \
+    -Dorg.apache.commons.logging.simplelog.showdatetime=true \
+    -Dorg.apache.commons.logging.simplelog.log.org.apache.http=DEBUG \
+    -Dorg.apache.commons.logging.simplelog.log.org.apache.http.wire=ERROR \
+    -jar MyFleetGirls.jar

--- a/update/build.sbt
+++ b/update/build.sbt
@@ -8,7 +8,10 @@ crossPaths := false
 
 autoScalaLibrary := false
 
-libraryDependencies ++= Seq()
+libraryDependencies ++= Seq(
+    "org.slf4j" % "slf4j-api" % "1.7.5",
+    "ch.qos.logback" % "logback-classic" % "1.1.2"
+)
 
 assemblySettings
 

--- a/update/build.sbt
+++ b/update/build.sbt
@@ -9,7 +9,7 @@ crossPaths := false
 autoScalaLibrary := false
 
 libraryDependencies ++= Seq(
-    "org.slf4j" % "slf4j-api" % "1.7.5",
+    "org.slf4j" % "slf4j-api" % "1.7.12",
     "ch.qos.logback" % "logback-classic" % "1.1.2"
 )
 

--- a/update/src/main/java/Main.java
+++ b/update/src/main/java/Main.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Properties;
 import java.security.GeneralSecurityException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 /**
@@ -18,33 +21,35 @@ import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
  * Date: 15/03/09.
  */
 public class Main {
+    private static Logger log = LoggerFactory.getLogger("com.ponkotuy.update");
+
     public static void main(String[] args) throws Exception {
         try {
             List<String> urls = getProperties("update.properties");
             for(String uStr : urls) {
                 URL url = new URL(uStr);
                 Path dst = Paths.get(url.getPath()).getFileName();
-                if(!Files.exists(dst)) {
-                    System.out.println(dst.getFileName() + "は存在しません。ダウンロードします。");
+                if(Files.exists(dst)) {
+                    log.info(dst.getFileName() + "の更新をチェックします。");
+                }else{
+                    log.info(dst.getFileName() + "は存在しません。ダウンロードします。");
                 }
                 URLConnection conn = Connection.withRedirect(url, getLastModified(dst));
                 if(conn == null) {
-                    System.out.println(dst.getFileName() + "に変更はありません");
+                    log.info(dst.getFileName() + "に変更はありません");
                 } else {
                     Connection.download(conn, dst);
-                    System.out.println(dst.getFileName() + "のダウンロードが完了しました");
+                    log.info(dst.getFileName() + "のダウンロードが完了しました");
                 }
             }
         } catch(MalformedURLException e) {
-            System.err.println("おやっ、URLの書式に異常です！ぽんこつさんが悪いです！");
+            log.error("おやっ、URLの書式に異常です！ぽんこつさんが悪いです！");
             System.exit(1);
         } catch(IOException e) {
-            System.err.println("おやっ、IOExceptionです！");
-            e.printStackTrace(System.err);
+            log.error("おやっ、IOExceptionです！",e);
             System.exit(1);
         } catch(GeneralSecurityException e) {
-            System.err.println("おやっ、SecurityException です！");
-            e.printStackTrace(System.err);
+            log.error("おやっ、SecurityException です！"e);
             System.exit(1);
         }
     }

--- a/update/src/main/resources/logback.xml
+++ b/update/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
             <level>INFO</level>
         </filter>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>%d{yyyy-MMM-dd HH:mm:ss.SSS} %-5level %marker %logger - %msg%n</Pattern>
+            <Pattern>%msg%n</Pattern>
         </layout>
     </appender>
 

--- a/update/src/main/resources/logback.xml
+++ b/update/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<configuration>
+    <property name="LoggingDir" value="logs/" />
+    <property name="ROOT_LEVEL" value="INFO" />
+    <timestamp key="byDate" datePattern="yyyyMMdd"/>
+
+    <appender name="INFO" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{yyyy-MMM-dd HH:mm:ss.SSS} %-5level %marker %logger - %msg%n</Pattern>
+        </layout>
+    </appender>
+
+    <appender name="ASYNC_INFO" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="INFO"/>
+    </appender>
+
+    <root level="${ROOT_LEVEL}">
+        <appender-ref ref="ASYNC_INFO"/>
+    </root>
+</configuration>


### PR DESCRIPTION
出力をロギングAPI 経由で出すと、設定ファイルだけで色々調整出来るよ。
コンソール非同期出力・ファイルへの書き出し・メールでの通知 etc...

jar ファイルのサイズもたいして変わらないよ。
PlayFramework とか httpclient なんかは log4j 使ってるから設定するだけで詳細な動作追えるねん。

API は SLF4J を使うのが良いよ。
実装は切り替えられるけど logback か log4j がお馴染みで説明も多いよ。
この辺の事情はここにまとまってる。ちょっと古いけど。
http://treeapps.hatenablog.com/entry/2012/10/20/java%E3%81%AE%E3%83%AD%E3%82%AC%E3%83%BC%E3%81%8C%E5%A4%9A%E3%81%99%E3%81%8E%E3%81%A6%E8%A8%B3%E3%81%8C%E8%A7%A3%E3%82%89%E3%81%AA%E3%81%84%E3%81%AE%E3%81%A7%E6%95%B4%E7%90%86%E3%81%97%E3%81%A6

Scala から SLF4J つかうなら ScalaLogging と言うラッパーが有るから使うと楽っぽい。
https://github.com/typesafehub/scala-logging
PlayFramework の中なら付属の Logger 使えばいいよ。あとで SLF4J 置き換えたり出来るし。