### PR TITLE
MyFleetGirls Server への通信に Proxy を設定出来るように

### DIFF
--- a/client/src/main/scala/com/ponkotuy/http/MFGHttp.scala
+++ b/client/src/main/scala/com/ponkotuy/http/MFGHttp.scala
@@ -3,6 +3,7 @@ package com.ponkotuy.http
 import java.io._
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
+import java.net.ProxySelector
 import javax.net.ssl.SSLContext
 
 import com.ponkotuy.config.ClientConfig
@@ -18,6 +19,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner
 import org.apache.http.message.BasicNameValuePair
 import org.apache.http.config.RegistryBuilder
 import org.apache.http.conn.socket.ConnectionSocketFactory
@@ -49,6 +51,7 @@ object MFGHttp extends Log {
       .setSslcontext(sslContext)
       .setConnectionTimeToLive(5 * 60 , TimeUnit.SECONDS)
       .setMaxConnPerRoute(1)
+      .setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
   val http = httpBuilder.build();
 
   implicit val formats = Serialization.formats(NoTypeHints)


### PR DESCRIPTION
艦これサーバーとの通信は無関係。

起動時に java -DproxyHost=localhost -DproxyPort=8888  -jar MyFleetGirls.jar
とか指定すると localhost:8888 な Proxy に接続に行きますよ。

指定しない場合は Proxy 使用しないので既存の動作に影響は無い。