### PR TITLE
Fix authentication error messages

### DIFF
--- a/server/app/controllers/Common.scala
+++ b/server/app/controllers/Common.scala
@@ -55,14 +55,14 @@ object Common extends Controller {
               reqHeadParse[MyFleetAuth](request)("auth2") match {
                 case Some(auth) =>
                   if(auth.id == oldAuth.memberId && Authentication.myfleetAuthOrCreate(auth)) f(ad)
-                  else Unauthorized("Failed Pasword Authentication")
+                  else Unauthorized("Password Authentication Failed")
                 case None =>
                   if(db.MyFleetAuth.find(oldAuth.memberId).isEmpty) f(ad)
-                  else Unauthorized("Require Password")
+                  else Unauthorized("Password Required")
               }
-            case None => Unauthorized("Failed Old Authentication")
+            case None => Unauthorized("Old Protocol Authentication Failed")
           }
-        case None => Unauthorized("Require Auth Data")
+        case None => Unauthorized("Authentication Data Required")
       }
     }
   }


### PR DESCRIPTION
もっと自然な英語になるようにしました。

* RequireをRequiredに変換して文の最後へ。
* Failedを文の最後へ。
* Old Authentication -> Old Protocol Authentication
  - Protocolを付加。
* Auth Data -> Authentication Data
  - `Auth` という単語はないようです。`Auth.` ならOK。

と、ここまでやってみてエラーメッセージは日本語で来た方が良いかも知れないですね…。
#213 にもありますし。
もしくはI18N対応するとかでしょうか。（ScalaのI18N事情をよく知らないです）