### PR TITLE
Fix proxy request URI

### DIFF
--- a/client/src/main/scala/com/ponkotuy/proxy/FinagleProxy.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/FinagleProxy.scala
@@ -22,7 +22,8 @@ class FinagleProxy(port: Int, inter: Intercepter) {
   val service = new Service[HttpRequest, HttpResponse] {
     def apply(req: HttpRequest): Future[HttpResponse] = {
       val uri = Uri.parse(req.getUri)
-      req.setUri(uri.pathRaw)
+      //req.setUri(uri.pathRaw)
+      req.setUri(uri.path + uri.queryString)
       val res = client(uri.host.get + ":80").apply(req)
       res.foreach(rs => inter.input(req, rs, uri))
       res


### PR DESCRIPTION
プロキシがリクエストを出す時にクエリパラメータがごっそりなくなってて専ブラとの連携が困難だったので修正しました。お使いいただければ幸いです。