### PR TITLE
URLのhashのqueryをエンコードするようにした

### DIFF
--- a/server/app/assets/javascript/from_ship.coffee
+++ b/server/app/assets/javascript/from_ship.coffee
@@ -59,7 +59,7 @@ vueSettings =
       @dropCounts = []
       @iCounts = []
     setHash: ->
-      param = query: @query
+      param = query: encodeURIComponent(@query)
       if @shipId != -1 then param.ship = @shipId
       else if @itemId != -1 then param.item = @itemId
       if @period


### PR DESCRIPTION
```
https://myfleet.moe/entire/sta/from_ship#query=大鯨&ship=184
```

https://github.com/ponkotuy/MyFleetGirls/blob/9f66a4cecbcec3e8a5778556fb9285376af86816/server/app/assets/javascript/delete_fav.coffee#L33 と同じで入れるときにエンコード