### PR TITLE
レベル、艦種ソートの結果をゲーム内と同様にする

### DIFF
--- a/server/app/views/user/ship.scala.html
+++ b/server/app/views/user/ship.scala.html
@@ -8,9 +8,9 @@
   @Js.ScriptFlot("time", "selection")
   <script src="@Js.MomentLocales"></script>
   <script src="@Js.Lodash"></script>
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/css/theme.bootstrap.css" />
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/jquery.tablesorter.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/jquery.tablesorter.widgets.min.js"></script>
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.16.4/css/theme.bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.16.4/jquery.tablesorter.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.16.4/jquery.tablesorter.widgets.min.js"></script>
   <script src="@Js.Common"></script>
   <script src="@Js.Coffee("graph")"></script>
   <script src="@Js.Coffee("ship")"></script>
@@ -78,10 +78,10 @@
             </tr>
           </thead>
           <tbody>
-            @ships.map { ship =>
+            @ships.sortBy(s => (s.master.sortno, s.id)).map { ship =>
             <tr>
               <td>@ship.id</td>
-              <td>@ship.stAbbName</td>
+              <td data-text="-@ship.stype.sortno">@ship.stAbbName</td>
               <td class="nowrap"><a data-toggle="modal" href="aship/@ship.id" class="modal_link" data-target="#modal">@ship.name</a></td>
               <td style="@if(ship.expRate > 0){background-color:#D9EDF7;display:block;width:@{(ship.expRate*100).toInt}%}">@ship.lv</td>
               <td style="padding:0px;"><div style="background-color:@if(ship.lv >= 100){#EBCCD1}else{#D9EDF7};width:@{(ship.entireExpRate*100).toInt}%;padding:5px;">@{f"${ship.exp}%,d"}</div></td>


### PR DESCRIPTION
#### 同ランクの物の並び順

tablesorterは安定なソートを行うので、tr要素を艦のsortno, 艦固有のIDでソートされるようにしました。
DBから読みだす際にorderByしてもよかったのですが、クエリが他所でも使われているようだったのでやめました。

#### 艦種ソート

tablesorter 2.16以降はtd要素のdata-text属性を優先して参照するのを利用しています。
厳密にテストしたわけではありませんが、特にバージョンアップに伴う不具合はないように思えます。
マイナスしているのはページ表示後、「艦種」ヘッダを最初にクリックしたときにゲーム内と同様の並び順にするためです。