### PR TITLE
Travis CI がタイムアウトするので回避設定

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - travis_wait sbt ++$TRAVIS_SCALA_VERSION test
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm


### PR DESCRIPTION
travis_wait を使うと良いらしいけど、使い方はこれであってるのだろうか。
http://docs.travis-ci.com/user/build-timeouts/#Build-times-out-because-no-output-was-received