### PR TITLE
小破判定を誤る場合があるのを修正

### DIFF
--- a/server/app/models/join/ShipParameter.scala
+++ b/server/app/models/join/ShipParameter.scala
@@ -144,6 +144,6 @@ object Damage {
   def fromHp(now: Int, max: Int): Option[Damage] =
     if(now <= max / 4) Some(Major)
     else if(now <= max / 2) Some(Half)
-    else if(now <= max / 4 * 3) Some(Minor)
+    else if(now <= max * 3 / 4) Some(Minor)
     else None
 }


### PR DESCRIPTION
端数切捨てのタイミングの違いにより、小破状態を通常状態と誤判定する場合がある事の修正です。

例えば最大HPが 10 の時は 3/4 の 7.5 ⇒ 端数切捨てで 7 以下が小破状態ですが、
10 / 4 で一旦端数の切捨てが行われる為、それの 3 倍で 6 以下を小破と判定していました。