### PR TITLE
Proxy サーバーからのレスポンスを gzip/deflate 圧縮しないように変更。

### DIFF
--- a/client/src/main/scala/com/ponkotuy/proxy/FinagleProxy.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/FinagleProxy.scala
@@ -6,7 +6,7 @@ import com.ponkotuy.intercept.Intercepter
 import com.ponkotuy.config.ClientConfig
 import com.twitter.conversions.storage._
 import com.twitter.conversions.time._
-import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.builder.{ClientBuilder, ServerBuilder}
 import com.twitter.finagle.{ChannelException, Http, Service, http}
 import com.twitter.util.{Await, Future}
 import org.jboss.netty.handler.codec.http.{HttpRequest, HttpResponse}
@@ -40,7 +40,11 @@ class FinagleProxy(host: String, port: Int, inter: Intercepter) {
   }
 
   val server = try {
-    Http.serve(s"$host:$port", service)
+    ServerBuilder()
+      .codec(http.Http().compressionLevel(0))
+      .bindTo(new InetSocketAddress(host,port))
+      .name("MyfleetGirlsProxy")
+      .build(service)
   } catch {
     case e: ChannelException =>
       e.printStackTrace()


### PR DESCRIPTION
現状 MyFleetGirls Proxy は艦これサーバーからの応答内容にかかわらず、クライアント（ 主にブラウザ ）に gzip 圧縮して送っている。

現実問題として Proxy より下位はローカルでの通信を想定するのでオーバーヘッドこそあれ、メリットはほぼ無い。

艦これサーバーからの応答内容に合わせる案もあるが netty 実装を掘り下げないとならない為、暫定的に上記対策を提案する。