### PR TITLE
[Client]デフォルトのconfを用意する #253

### DIFF
--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -1,0 +1,38 @@
+# 頭に#はコメントです
+
+# MyFleetGirls のデータ送信先サーバーアドレスです。
+# 通常変更する必要はありません
+url {
+    post: "https://myfleet.moe"
+
+    # 上記URLに接続する際のProxy設定です。一般的な環境では必要ないでしょう。
+    proxy {
+        # host: "localhost"
+        # port: 8888
+    }
+}
+
+proxy {
+    # MyFleetGirls Clientはこのポート番号で proxy として待ち受けます。
+    # 他の proxy ツールと併用する場合等重複しないようにしてください
+    port: 8080
+
+    # MyFleetGirls Clientへの接続をlocalhostに制限します。
+    # 制限したくない場合は""(空文字列)を指定してください。
+    # セキュリティ的な問題が発生するので、変更しないことを推奨します。
+    host: "localhost"
+}
+
+# 艦これサーバーに接続するときに使用する上位プロキシを指定します
+upstream_proxy {
+    # host: "localhost"
+    # port: 8888
+}
+
+auth {
+    # MyFleetGirls サーバーとの通信にパスワードを設定します
+    # 一度設定すると以降殆どの通信、及び Web でのログインに必要となります
+    # パスワードを忘れた場合の対処等は MyFleetGirls Web の FAQ を参照してください
+
+    # pass: abcde
+}

--- a/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
+++ b/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
@@ -1,6 +1,9 @@
 package com.ponkotuy.config
 
-import java.io.File
+import java.io.{BufferedReader, File, InputStreamReader}
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{Files, Path}
+import java.util.stream.Collectors
 
 import com.ponkotuy.data.MyFleetAuth
 import com.typesafe.config.ConfigFactory
@@ -16,7 +19,19 @@ import scala.util.Try
 object ClientConfig {
   lazy val config = {
     val file = new File("application.conf")
+    if (!file.exists()) {
+      createDefaultAppConfig(file.toPath)
+    }
     ConfigFactory.parseFile(file).withFallback(ConfigFactory.defaultReference())
+  }
+
+  private def createDefaultAppConfig(path: Path): Unit = {
+    val default = getClass.getResourceAsStream("/reference.conf")
+    val reader = new BufferedReader(new InputStreamReader(default, StandardCharsets.UTF_8))
+    try
+      Files.write(path, reader.lines().collect(Collectors.toList()), Charset.defaultCharset())
+    finally
+      reader.close()
   }
 
   lazy val post = config.getString("url.post")

--- a/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
+++ b/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
@@ -16,11 +16,7 @@ import scala.util.Try
 object ClientConfig {
   lazy val config = {
     val file = new File("application.conf")
-    if(file.exists()) {
-      ConfigFactory.parseFile(file)
-    } else {
-      ConfigFactory.parseFile(new File("application.conf.sample"))
-    }
+    ConfigFactory.parseFile(file).withFallback(ConfigFactory.defaultReference())
   }
 
   lazy val post = config.getString("url.post")


### PR DESCRIPTION
Fix #253 
* reference.confにデフォルト設定を用意してfallback
* application.confが存在しなかった場合、reference.confを元に自動生成