### PR TITLE
Avoid sbt command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ cache:
 jdk:
   - oraclejdk8
 
-before_script:
-  - travis_wait sbt downLib
-
 script:
   - travis_wait sbt test
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/README.org
+++ b/README.org
@@ -39,7 +39,7 @@ $ sbt proxy
    - run :: サーバを立ち上げます。ただし開発モード
    - start :: 同上。ただし本番モード
    - proxy :: client立ち上げ
-   - assembl :: MyFleetGirls ClientのダウンローダとClient本体をone-packageのjarに固める
+   - assembly :: MyFleetGirls ClientのダウンローダとClient本体をone-packageのjarに固める
    - zip :: assemblyののちに、publicにそれらを配置する
    - prof :: profilerを立ち上げる（メンテされてないので動くか不明）
    - downLib :: 非maven管理下にあるjarをdownloadし適切に配置する


### PR DESCRIPTION
CommandよりTaskの方が使い勝手がよいのでTask使おう。

serverのコンパイル前にdownLibを自動で実行するようにした。

startは元がCommandなのでTaskにできない。
(Playのstartは非推奨でtestProdに変更されている。masterでは更にtestProdが非推奨でrunProdに)
