### PR TITLE
Fix proxy InetAddress

### DIFF
--- a/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
+++ b/client/src/main/scala/com/ponkotuy/config/ClientConfig.scala
@@ -47,7 +47,10 @@ object ClientConfig {
   def proxyPort = config.getInt("proxy.port")
 
   // 接続可能範囲(デフォルトではlocalhostのみ受け付け
-  def proxyHost = Try { config.getString("proxy.host") }.getOrElse("localhost")
+  def proxyHost = Try {
+    val raw = config.getString("proxy.host").stripMargin
+    if (raw == "") None else Some(raw)
+  }.getOrElse(Some("localhost"))
 
   // MyFleetGirlsへの接続に使われるProxy設定
   lazy val clientProxyHost: Option[HttpHost] = {

--- a/client/src/main/scala/com/ponkotuy/proxy/LittleProxy.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LittleProxy.scala
@@ -11,13 +11,17 @@ import org.littleshoot.proxy.{ChainedProxy, ChainedProxyAdapter, ChainedProxyMan
 import scala.util.control.NonFatal
 
 
-class LittleProxy(host: String, port: Int, upstreamProxy: Option[HttpHost], filtersSource: HttpFiltersSource) {
+class LittleProxy(host: Option[String], port: Int, upstreamProxy: Option[HttpHost], filtersSource: HttpFiltersSource) {
 
   import LittleProxy._
 
-  private val bootstrap = DefaultHttpProxyServer.bootstrap()
+  private[this] val inetSocketAddress = host.fold(new InetSocketAddress(port)) { address =>
+    new InetSocketAddress(address, port)
+  }
+
+  private[this] val bootstrap = DefaultHttpProxyServer.bootstrap()
     .withName("MyFleetGirlsProxy")
-    .withAddress(new InetSocketAddress(host, port))
+    .withAddress(inetSocketAddress)
     .withConnectTimeout(30000)
     .withUpstreamProxy(upstreamProxy)
     .withFiltersSource(filtersSource)


### PR DESCRIPTION
Clientのapplication.confに

```
    # MyFleetGirls Clientへの接続をlocalhostに制限します。                               
    # 制限したくない場合は""(空文字列)を指定してください。                               
    # セキュリティ的な問題が発生するので、変更しないことを推奨します。    
```

と書いてあるにも関わらず空文字列でlocalhostのみ受け付けるようになっているので修正