### PR TITLE
コンソールへのログ出力をカラーリングする

### DIFF
--- a/client/build.sbt
+++ b/client/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpmime" % "4.5.2",
   "com.typesafe.akka" %% "akka-actor" % "2.4.6",
   "ch.qos.logback" % "logback-classic" % "1.1.7" % "runtime",
+  "org.fusesource.jansi" % "jansi" % "1.13",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )
 

--- a/client/src/main/resources/logback.xml
+++ b/client/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
     <!-- withJansi is enables ANSI color code interpretation by the Jansi library on Windows -->
     <withJansi>true</withJansi>
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+      <pattern>%green(%d{HH:mm:ss}) [%thread] %highlight(%-5level) %cyan(%logger{5}) - %msg%n</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>

--- a/client/src/main/resources/logback.xml
+++ b/client/src/main/resources/logback.xml
@@ -18,6 +18,8 @@
   </appender>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- withJansi is enables ANSI color code interpretation by the Jansi library on Windows -->
+    <withJansi>true</withJansi>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
     </encoder>


### PR DESCRIPTION
Windows 7 / OS X での動作は確認済み。

ログファイルへのエスケープシーケンスの混入は戸惑われたのでとりあえずはやらず。