### PR TITLE
Console への出力を SLF4J に置き換える ( #374 の暫定対応 ）

### DIFF
--- a/client/build.sbt
+++ b/client/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpmime" % "4.5.2",
   "com.typesafe.akka" %% "akka-actor" % "2.4.6",
   "ch.qos.logback" % "logback-classic" % "1.1.7" % "runtime",
-  "uk.org.lidalia" $ "sysout-over-slf4j" % "1.0.2",
+  "uk.org.lidalia" % "sysout-over-slf4j" % "1.0.2",
   "org.fusesource.jansi" % "jansi" % "1.13",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpmime" % "4.5.2",
   "com.typesafe.akka" %% "akka-actor" % "2.4.6",
   "ch.qos.logback" % "logback-classic" % "1.1.7" % "runtime",
+  "uk.org.lidalia" $ "sysout-over-slf4j" % "1.0.2",
   "org.fusesource.jansi" % "jansi" % "1.13",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )

--- a/client/src/main/resources/logback.xml
+++ b/client/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
     <!-- withJansi is enables ANSI color code interpretation by the Jansi library on Windows -->
     <withJansi>true</withJansi>
     <encoder>
-      <pattern>%green(%d{HH:mm:ss}) [%thread] %highlight(%-5level) %cyan(%logger{5}) - %msg%n</pattern>
+      <pattern>%green(%d{HH:mm:ss}) [%thread] %highlight(%-5level) %cyan(%replace(%logger{5}){'s.Console',''}) - %msg%n%red(%xEx{short})</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>

--- a/client/src/main/scala/com/ponkotuy/run/Main.scala
+++ b/client/src/main/scala/com/ponkotuy/run/Main.scala
@@ -8,6 +8,7 @@ import com.ponkotuy.proxy.{KCFiltersSource, LittleProxy}
 import com.ponkotuy.util.Log
 import com.ponkotuy.value.KCServer
 import io.netty.util.ResourceLeakDetector
+import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J
 
 /**
  *
@@ -16,6 +17,7 @@ import io.netty.util.ResourceLeakDetector
  */
 object Main extends App with Log {
   ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED)
+  SysOutOverSLF4J.sendSystemOutAndErrToSLF4J()
   try {
     message()
 

--- a/client/src/main/scala/com/ponkotuy/run/Main.scala
+++ b/client/src/main/scala/com/ponkotuy/run/Main.scala
@@ -9,6 +9,7 @@ import com.ponkotuy.util.Log
 import com.ponkotuy.value.KCServer
 import io.netty.util.ResourceLeakDetector
 import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J
+import uk.org.lidalia.sysoutslf4j.context.LogLevel
 
 /**
  *
@@ -17,7 +18,7 @@ import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J
  */
 object Main extends App with Log {
   ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED)
-  SysOutOverSLF4J.sendSystemOutAndErrToSLF4J()
+  SysOutOverSLF4J.sendSystemOutAndErrToSLF4J(LogLevel.WARN,LogLevel.ERROR)
   try {
     message()
 


### PR DESCRIPTION
#374 の全部を一気に書き換えるのは手間がかかるので、scala.Console への出力を SLF4J にリダイレクトするライブラリ（ sysout-over-slf4j  ）を使用してみる。

STDOUT への出力は WARN , STDERR への出力は ERROR レベルとしてロギングされるように設定。
ログレベルはもう一段階下の方が適切だけど、 logback.xml で CONSOLE への出力を WARN でフィルタしてある事から。