### PR TITLE
Log4j の出力を SLF4J に切り替える。 （ refs #374 ）

### DIFF
--- a/client/build.sbt
+++ b/client/build.sbt
@@ -10,6 +10,8 @@ libraryDependencies ++= Seq(
   "com.netaporter" %% "scala-uri" % "0.4.14",
   "org.apache.httpcomponents" % "httpclient" % "4.5.2",
   "org.apache.httpcomponents" % "httpmime" % "4.5.2",
+  "org.slf4j" % "slf4j-api" % "1.7.21",
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
   "com.typesafe.akka" %% "akka-actor" % "2.4.6",
   "ch.qos.logback" % "logback-classic" % "1.1.7" % "runtime",
   "org.fusesource.jansi" % "jansi" % "1.13",


### PR DESCRIPTION
#374 に関連して。
Commons-HttpClient が Log4j を使用している。
SLF4J 側で用意されている log4j-over-slf4j アダプターを読み込ませることで切り替えられる。