### PR TITLE
各 Request/Response をログに記録するように。

### DIFF
--- a/client/src/main/scala/com/ponkotuy/proxy/LittleProxy.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LittleProxy.scala
@@ -35,6 +35,7 @@ class LittleProxy(host: Option[String], port: Int, upstreamProxy: Option[HttpHos
     .withConnectTimeout(30000)
     .withUpstreamProxy(upstreamProxy)
     .withFiltersSource(filtersSource)
+    .plusActivityTracker(new LoggingActivityTracker)
     .withThreadPoolConfiguration(defaultThreadPoolConf)
 
   def start(): Unit = {

--- a/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
@@ -1,0 +1,40 @@
+package com.ponkotuy.proxy
+
+import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.HttpResponse
+
+import java.net.InetSocketAddress
+import javax.net.ssl.SSLSession
+
+import org.littleshoot.proxy._
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class LoggingActivityTracker extends ActivityTrackerAdapter {
+
+  lazy val logger = LoggerFactory.getLogger(getClass)
+
+  // override def bytesReceivedFromClient(flowContext: FlowContext,numberOfBytes: Int): Unit = {}
+
+  override def requestReceivedFromClient(flowContext: FlowContext,httpRequest: HttpRequest): Unit = {}
+
+  // override def bytesSentToServer(flowContext: FullFlowContext,numberOfBytes: Int): Unit = {}
+
+  override def requestSentToServer(flowConext: FullFlowContext,httpRequest: HttpRequest): Unit = {}
+
+  override def bytesReceivedFromServer(flowConext: FullFlowContext,numberOfBytes: Int): Unit = {}
+
+  override def responseReceivedFromServer(flowContext: FullFlowContext,httpResponce: HttpResponse): Unit = {}
+
+  // override def bytesSentToClient(flowContext: FullFlowContext,numberOfBytes: Int): Unit = {}
+
+  override def responseSentToClient(flowContext: FlowContext,httpResponse: HttpResponse): Unit = {}
+
+  override def clientConnected(clientAddress: InetSocketAddress): Unit = {}
+
+  // override def clientSSLHandshakeSucceeded(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {}
+
+  override def clientDisconnected(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {}
+}
+

--- a/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 import javax.net.ssl.SSLSession
 
 import io.netty.handler.codec.http.{HttpRequest,HttpResponse}
+import io.netty.handler.codec.http.HttpHeaders
 
 import org.littleshoot.proxy._
 
@@ -23,15 +24,25 @@ class LoggingActivityTracker extends ActivityTrackerAdapter {
   }
 
   override def bytesReceivedFromServer(flowConext: FullFlowContext,numberOfBytes: Int): Unit = {
-    logger.trace("response received from server to proxy. {} bytes",numberOfBytes);
+    logger.trace("response received from server to proxy. {} bytes",numberOfBytes)
   }
 
   override def responseReceivedFromServer(flowContext: FullFlowContext,httpResponse: HttpResponse): Unit = {
-    logger.debug("response received from server to proxy. STATUS:{}",httpResponse.getStatus);
+    logger.debug(
+      "response received from server to proxy. Status:{}, Transfer:{}, Content:{}",
+      httpResponse.getStatus,
+      httpResponse.headers.get(HttpHeaders.Names.TRANSFER_ENCODING),
+      httpResponse.headers.get(HttpHeaders.Names.CONTENT_ENCODING)
+    )
   }
 
   override def responseSentToClient(flowContext: FlowContext,httpResponse: HttpResponse): Unit = {
-    logger.debug("response sent to client from proxy. STATUS:{}",httpResponse.getStatus);
+    logger.debug(
+      "response sent to client from proxy. Status:{}, Transfer:{}, Content:{}",
+      httpResponse.getStatus,
+      httpResponse.headers.get(HttpHeaders.Names.TRANSFER_ENCODING),
+      httpResponse.headers.get(HttpHeaders.Names.CONTENT_ENCODING)
+    )
   }
 
   override def clientConnected(clientAddress: InetSocketAddress): Unit = {

--- a/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
@@ -46,11 +46,11 @@ class LoggingActivityTracker extends ActivityTrackerAdapter {
   }
 
   override def clientConnected(clientAddress: InetSocketAddress): Unit = {
-    logger.info("Client Connected from:{}",clientAddress.toString);
+    logger.info("Client Connected from:{}",clientAddress);
   }
 
   override def clientDisconnected(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {
-    logger.info("Client DisConnected from:{}",clientAddress.toString)
+    logger.info("Client DisConnected from:{}",clientAddress)
   }
 }
 

--- a/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
@@ -1,10 +1,9 @@
 package com.ponkotuy.proxy
 
-import io.netty.handler.codec.http.HttpRequest
-import io.netty.handler.codec.http.HttpResponse
-
 import java.net.InetSocketAddress
 import javax.net.ssl.SSLSession
+
+import io.netty.handler.codec.http.{HttpRequest,HttpResponse}
 
 import org.littleshoot.proxy._
 
@@ -15,26 +14,32 @@ class LoggingActivityTracker extends ActivityTrackerAdapter {
 
   lazy val logger = LoggerFactory.getLogger(getClass)
 
-  // override def bytesReceivedFromClient(flowContext: FlowContext,numberOfBytes: Int): Unit = {}
+  override def requestReceivedFromClient(flowContext: FlowContext,httpRequest: HttpRequest): Unit = {
+    logger.debug("request received from client to proxy. URL:{}",httpRequest.getUri)
+  }
 
-  override def requestReceivedFromClient(flowContext: FlowContext,httpRequest: HttpRequest): Unit = {}
+  override def requestSentToServer(flowConext: FullFlowContext,httpRequest: HttpRequest): Unit = {
+    logger.debug("request sent proxy to server. URL:{}",httpRequest.getUri)
+  }
 
-  // override def bytesSentToServer(flowContext: FullFlowContext,numberOfBytes: Int): Unit = {}
+  override def bytesReceivedFromServer(flowConext: FullFlowContext,numberOfBytes: Int): Unit = {
+    logger.trace("response received from server to proxy. {} bytes",numberOfBytes);
+  }
 
-  override def requestSentToServer(flowConext: FullFlowContext,httpRequest: HttpRequest): Unit = {}
+  override def responseReceivedFromServer(flowContext: FullFlowContext,httpResponse: HttpResponse): Unit = {
+    logger.debug("response received from server to proxy. STATUS:{}",httpResponse.getStatus);
+  }
 
-  override def bytesReceivedFromServer(flowConext: FullFlowContext,numberOfBytes: Int): Unit = {}
+  override def responseSentToClient(flowContext: FlowContext,httpResponse: HttpResponse): Unit = {
+    logger.debug("response sent to client from proxy. STATUS:{}",httpResponse.getStatus);
+  }
 
-  override def responseReceivedFromServer(flowContext: FullFlowContext,httpResponce: HttpResponse): Unit = {}
+  override def clientConnected(clientAddress: InetSocketAddress): Unit = {
+    logger.info("Client Connected from:{}",clientAddress.toString);
+  }
 
-  // override def bytesSentToClient(flowContext: FullFlowContext,numberOfBytes: Int): Unit = {}
-
-  override def responseSentToClient(flowContext: FlowContext,httpResponse: HttpResponse): Unit = {}
-
-  override def clientConnected(clientAddress: InetSocketAddress): Unit = {}
-
-  // override def clientSSLHandshakeSucceeded(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {}
-
-  override def clientDisconnected(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {}
+  override def clientDisconnected(clientAddress: InetSocketAddress,sslSession: SSLSession): Unit = {
+    logger.info("Client DisConnected from:{}",clientAddress.toString)
+  }
 }
 

--- a/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
+++ b/client/src/main/scala/com/ponkotuy/proxy/LoggingActivityTracker.scala
@@ -8,12 +8,9 @@ import io.netty.handler.codec.http.HttpHeaders
 
 import org.littleshoot.proxy._
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import com.ponkotuy.util.Log
 
-class LoggingActivityTracker extends ActivityTrackerAdapter {
-
-  lazy val logger = LoggerFactory.getLogger(getClass)
+class LoggingActivityTracker extends ActivityTrackerAdapter with Log {
 
   override def requestReceivedFromClient(flowContext: FlowContext,httpRequest: HttpRequest): Unit = {
     logger.debug("request received from client to proxy. URL:{}",httpRequest.getUri)


### PR DESCRIPTION
Log を取る為の ActivityTracker を追加する。
これにより client -> proxy -> server -> proxy -> client の流れが可視化する。