### PR TITLE
対空カットインの更新

### DIFF
--- a/library/src/main/scala/com/ponkotuy/value/ShipIds.scala
+++ b/library/src/main/scala/com/ponkotuy/value/ShipIds.scala
@@ -61,6 +61,9 @@ object ShipIds {
   val Okinami = 452
   val KasumiMk2Otsu = 470
   val Amagiri = 479
+  val KinuMk2 = 487
+  val YuraMk2 = 488
+  val FumidukiMk2 = 548
 
   def isEnemy(id: Int): Boolean = 1500 < id
 }

--- a/server/app/tool/AntiAirCutin.scala
+++ b/server/app/tool/AntiAirCutin.scala
@@ -18,6 +18,9 @@ trait AntiAirCutin {
         .orElse(isuzuMk2Cutin)
         .orElse(kasumiCutin)
         .orElse(satsukiCutin)
+        .orElse(kinuCutin)
+        .orElse(yuraCutin)
+        .orElse(fumidukiCutin)
         .orElse(battleshipCutin)
         .orElse(commonCutin)
 
@@ -64,6 +67,23 @@ trait AntiAirCutin {
     if(hasManyGun) Some(2) else None
   }
 
+  private def kinuCutin: Option[Int] = {
+    if(shipId != KinuMk2) return None
+    if(hasManyGun) {
+      Some(if(countGun > 0 && !hasWithGun) 5 else 3)
+    } else None
+  }
+
+  private def yuraCutin: Option[Int] = {
+    if(shipId != YuraMk2) return None
+    if(countGun > 0 && hasAntiAirRadar) Some(5) else None
+  }
+
+  private def fumidukiCutin: Option[Int] = {
+    if(shipId != FumidukiMk2) return None
+    if(hasManyGun) Some(2) else None
+  }
+
   private def commonCutin: Option[Int] = {
     if(hasWithGun && hasAntiAirRadar) Some(4)
     else if(countGun > 0 && hasSystem && hasAntiAirRadar) Some(3)
@@ -102,7 +122,7 @@ object AntiAirCutin {
   val AkidukiType = Set(Akiduki, Teruduki, Hatsuduki, AkidukiMk1, TerudukiMk1, HatsudukiMk1) // 秋月型
   val ManyAntiAirGun = Set(131, 173, 191) // 25mm三連装機銃 集中配備など
   val AntiAirRadar = Set(27, 30, 32, 89, 106) // 対空電探
-  val SystemWithGun = Set(122, 130, 135) // 高角砲 + 高射装置
+  val SystemWithGun = Set(122, 130, 135, 172) // 高角砲 + 高射装置
   val AntiAirSystem = Set(120, 121, 122, 130, 135) // 高射装置を含む
   val Battleship = Set("戦艦", "航空戦艦")
 }


### PR DESCRIPTION
・鬼怒改二, 由良改二, 文月改二のカットインを追加
・高射装置付き扱いに 5inch連装砲 Mk.28 mod.2 を追加

Scalaがよく判っていないので変な事をしてたらすみません。